### PR TITLE
Support some rare case of get_one()

### DIFF
--- a/sphinxcontrib/pecanwsme/rest.py
+++ b/sphinxcontrib/pecanwsme/rest.py
@@ -163,16 +163,22 @@ class RESTControllerDirective(rst.Directive):
         # include the name of the argument used to find the object.
         if hasattr(controller, 'get_one') and controller.get_one.exposed:
             app.info('Found method: get_one')
-            funcdef = controller.get_one._wsme_definition
-            first_arg_name = funcdef.arguments[0].name
-            path = controller_path + '/(' + first_arg_name + ')'
-            lines.extend(
-                self.make_rst_for_method(
-                    path,
-                    controller.get_one,
-                    'get',
+            funcdef = getattr(controller.get_one, '_wsme_definition', None)
+            if funcdef:
+                path = None
+                for arg in funcdef.arguments:
+                    sub_path = '/(' + arg.name + ')'
+                    if sub_path in controller_path:
+                        continue
+                    path = controller_path + sub_path
+                    break
+                lines.extend(
+                    self.make_rst_for_method(
+                        path,
+                        controller.get_one,
+                        'get',
+                    )
                 )
-            )
 
         for method_name, http_method_name in [('post', 'post'),
                                               ('put', 'put'),


### PR DESCRIPTION
There is some special case for get_one usgae, for i.e., Ceilometer
disable /v2/event_type/(event_type), so user GET that API will return
404 error. But this url should be exposed to pecan, so
/v2/event_type/(event_type)/traits url can be routed. In such
situation, get_one() will not have wsme_definition.

Currently, we support /v2/event_type/(event_type)/(trait_name), which
means, TraitController has **init**(self, event_type) and get_one(self,
traint_name). But what if /v2/event_type/(event_type)/traits/(trait_name)
is what api want? This patch adds such support by check arguments of
get_one(), and filter out argument.name which already in webprefix.

Related-Bug: #1388514
